### PR TITLE
Fix menuconfig error in gcc-14 above

### DIFF
--- a/support/kconfig/lxdialog/check-lxdialog.sh
+++ b/support/kconfig/lxdialog/check-lxdialog.sh
@@ -48,7 +48,7 @@ trap "rm -f $tmp" 0 1 2 3 15
 check() {
         $cc -x c - -o $tmp 2>/dev/null <<'EOF'
 #include CURSES_LOC
-main() {}
+int main() {}
 EOF
 	if [ $? != 0 ]; then
 	    echo " *** Unable to find the ncurses libraries or the"       1>&2


### PR DESCRIPTION
- ubuntu 25.04
- gcc 14.2.0 (x64)

when `make menuconfig`, an error occured:
```bash
  *** 'make menuconfig' requires the ncurses libraries.
  ***
  *** Install ncurses (ncurses-devel or libncurses-dev
  *** depending on your distribution) and try again.
```
it caused by the confict of `-std=c99` and `main() {}`, just add a int